### PR TITLE
Updated text of 'duration' for PerformanceMainFrameTiming events.

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,7 +173,7 @@
             <p>
               The <code>startTime</code> attribute will return a <a href="http://www.w3.org/TR/hr-time/#domhighrestimestamp"><code>DOMHighResTimeStamp</code></a> with current frame's beginning time value (identical to the frame beginning time used for <a href="https://dvcs.w3.org/hg/webperf/raw-file/tip/specs/RequestAnimationFrame/Overview.html#processingmodel">requestAnimationFrame</a> callbacks) [[HR-Time]].</p>
             <p>
-              The <code>duration</code> attribute will return a <a href="http://www.w3.org/TR/hr-time/#domhighrestimestamp"><code>DOMHighResTimeStamp</code></a> with the duration of the frame, computed by subtracting the <code>startTime</code> of the next frame from <code>startTime</code> of the current frame.</p>
+              The <code>duration</code> attribute will return a <a href="http://www.w3.org/TR/hr-time/#domhighrestimestamp"><code>DOMHighResTimeStamp</code></a> with either: <ul><li><code>thisMainFrame.startTime</code> - <code><a href="https://dvcs.w3.org/hg/webperf/raw-file/tip/specs/NavigationTiming/Overview.html#dom-performancetiming-navigationstart">navigationStart</a></code></li><li>or <code>thisMainFrame.startTime</code> - <code>lastMainFrame.startTime</code>.</li></ul></p>
           </div>
         </p>
         <p>


### PR DESCRIPTION
As per discussion in issue #3 
