### PR TITLE
update Duration and cpuTime descriptions per dicussion

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,7 +173,7 @@
             <p>
               The <code>startTime</code> attribute will return a <a href="http://www.w3.org/TR/hr-time/#domhighrestimestamp"><code>DOMHighResTimeStamp</code></a> with current frame's beginning time value (identical to the frame beginning time used for <a href="https://dvcs.w3.org/hg/webperf/raw-file/tip/specs/RequestAnimationFrame/Overview.html#processingmodel">requestAnimationFrame</a> callbacks) [[!HR-Time]].</p>
             <p>
-              The <code>duration</code> attribute will return a <a href="http://www.w3.org/TR/hr-time/#domhighrestimestamp"><code>DOMHighResTimeStamp</code></a> with the duration of the frame, computed by subtracting the <code>startTime</code> of the next frame from <code>startTime</code> of the current frame.</p>
+              The <code>duration</code> attribute will return a <a href="http://www.w3.org/TR/hr-time/#domhighrestimestamp"><code>DOMHighResTimeStamp</code></a> with the duration of the frame, computed by subtracting the <code>startTime</code> of the current frame from the next possible v-sync boundary, or <code>startTime</code> of the next frame, if available. <code>duration</code> should capture the entire wall-clock duration of the current frame, INLCUDING any idle, blocking or descheduled time.</p>
           </div>
         </p>
         <p>
@@ -184,7 +184,7 @@
             </dd>
             <dt>readonly attribute DOMHighResTimeStamp cpuTime</dt>
             <dd>
-              This attribute must return a <a href="#bib-HR-Time">[High Resolution Time]</a> duration giving the total CPU time used to process this frame.
+              This attribute must return a <a href="#bib-HR-Time">[High Resolution Time]</a> duration giving the actual wall-clock time used to process this frame EXCLUDING any idle time. The user agent SHOULD include the time spent on JavaScript execution, accessing and modifying the DOM and CSSOM, and other relevant processing operations required to render the frame (e.g. layout, style recalculations, painting, and so on).
             </dd>
         </dl>
         </p>


### PR DESCRIPTION
Updating description for 'duration' and 'cpuTime' parameters for issue #3.

This clarifies a few points: 
1) duration is measured as per requestAnimationFrame's definition of "start time" until the next VSYNC boundary this frame can make. This means duration will be approximately 16, 32, etc for ~60 FPS, depending on if you made or missed a particular deadline. It is a binary signal showing that you are missing deadlines.

2) 'cpuTime' captures wall clock EXCLUDING idle time. It is meant to show how much headroom you have when you make a deadline, or how much you missed by, when you miss one (or more.)

3) cpuTime is not an OS-level CPU time, it continues counting if the thread is descheduled and is a MAX() not a SUM() of all concurrent threads processing (if there are more than one thread). This is intentional because as a web developer, you have some amount of resources to use and are trying to use them to achieve a desired effect (smoothly!) It is the kernel and the user agent's job to manage system resources, and distribute time fairly. 

Please let me know if the wording is clear, and if this makes sense in a vendor-agnostic way.
Thanks!
