### PR TITLE
Change name from cpuTime to cost

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,7 +182,7 @@
             <dd>
               This attribute must return the source frame number for the event. This is used to correlate <code>PerformanceRenderTiming</code> and <code>PerformanceCompositeTiming</code> events to measure time-to-frame delays.
             </dd>
-            <dt>readonly attribute DOMHighResTimeStamp cpuTime</dt>
+            <dt>readonly attribute DOMHighResTimeStamp cost</dt>
             <dd>
               This attribute must return a <a href="#bib-HR-Time">[High Resolution Time]</a> duration giving the total CPU time used to process this frame.
             </dd>


### PR DESCRIPTION
Change name from cpuTime to cost to reflect the fact that it is wall-clock time, not cpu time, as per #22 
