### PR TITLE
Add [Exposed=Window] to interface PerformanceFrameTiming

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,7 +129,8 @@
     <h2>Frame Timing</h2>
     <section>
       <h2><dfn>PerformanceFrameTiming</dfn> interface</h2>
-      <pre class="idl">interface PerformanceFrameTiming : PerformanceEntry {
+      <pre class="idl">[Exposed=Window]
+interface PerformanceFrameTiming : PerformanceEntry {
 };</pre>
       <section>
         <h2>Attributes</h2>


### PR DESCRIPTION
This is required by Web IDL.